### PR TITLE
Add missing libgmp to tugboat image

### DIFF
--- a/tugboat-php/Dockerfile
+++ b/tugboat-php/Dockerfile
@@ -15,3 +15,9 @@ RUN ln -s /etc/apache2/mods-available/rewrite.load /etc/apache2/mods-enabled/rew
 RUN echo "memory_limit = 512M" >> /usr/local/etc/php/conf.d/my-php.ini
 
 RUN rm -rf $DOCROOT/../html.original $DOCROOT
+
+# GMP library.
+RUN apt-get install -y libgmp-dev
+RUN ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/local/include/
+RUN docker-php-ext-configure gmp
+RUN docker-php-ext-install gmp


### PR DESCRIPTION
This image was created with a missing GMP lib, this will add the missing lib.

This is the built container at docker ui

![image](https://github.com/goalgorilla/ci_images/assets/11061892/ffc71152-82dc-4375-a710-1accfa6b4b64)
