### PR TITLE
Update Dockerfile to add `ext-intl`

### DIFF
--- a/tugboat-php/Dockerfile
+++ b/tugboat-php/Dockerfile
@@ -21,3 +21,8 @@ RUN apt-get install -y libgmp-dev
 RUN ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/local/include/
 RUN docker-php-ext-configure gmp
 RUN docker-php-ext-install gmp
+
+# simplesamlphp/simplesamlphp 2.1.0 requires ext-intl.
+RUN apt-get install -y zlib1g-dev libicu-dev g++
+RUN docker-php-ext-configure intl
+RUN docker-php-ext-install intl


### PR DESCRIPTION
`simplesamlphp/simplesamlphp:2.1.0` requires `ext-intl` so we have to add it here in order for tugboat to work on our D10 compatible releases that have this version constraint.

