### PR TITLE
Adjust our dockerfile to make sure our var/solr/data directory exist.

### DIFF
--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -2,6 +2,11 @@ ARG VERSION=latest
 ARG CONFIG_VERSION=9
 
 FROM solr:$VERSION
+RUN mkdir -p /var/solr/data /var/solr/logs; \
+  (cd /opt/solr/server/solr; cp solr.xml zoo.cfg /var/solr/data/); \
+  cp /opt/solr/server/resources/log4j2.xml /var/solr/log4j2.xml; \
+  find /var/solr -type d -print0 | xargs -0 chmod 0770; \
+  find /var/solr -type f -print0 | xargs -0 chmod 0660;
 
 ARG CONFIG_VERSION
 

--- a/tugboat-solr/Dockerfile
+++ b/tugboat-solr/Dockerfile
@@ -2,6 +2,11 @@ ARG VERSION=latest
 ARG CONFIG_VERSION=9
 
 FROM tugboatqa/solr:$VERSION
+RUN mkdir -p /var/solr/data /var/solr/logs; \
+  (cd /opt/solr/server/solr; cp solr.xml zoo.cfg /var/solr/data/); \
+  cp /opt/solr/server/resources/log4j2.xml /var/solr/log4j2.xml; \
+  find /var/solr -type d -print0 | xargs -0 chmod 0770; \
+  find /var/solr -type f -print0 | xargs -0 chmod 0660;
 
 ARG CONFIG_VERSION
 


### PR DESCRIPTION
In the new solr the /var/solr initialization has been removed from our docker file.
https://issues.apache.org/jira/browse/SOLR-15001

To make sure we still have this directory as we depend on it, we create it during our own adjustments for solr.